### PR TITLE
Removed clojure 1.4.0 dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
   :url "https://github.com/hugoduncan/clj-ssh"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/tools.logging "0.2.6"
+  :dependencies [[org.clojure/tools.logging "0.2.6"
                   :exclusions [org.clojure/clojure]]
                  [com.jcraft/jsch.agentproxy.usocket-jna ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.usocket-nc ~agentproxy-version]


### PR DESCRIPTION
The project that will use clj-ssh already has clojure as a dependendency and the library doesn't need to add it too.