### PR TITLE
clj-ssh/download: fix :recursive and :preserve flags.

### DIFF
--- a/src/clj_ssh/ssh.clj
+++ b/src/clj_ssh/ssh.clj
@@ -1084,8 +1084,9 @@ cmd specifies a command to exec.  Valid commands are:
                  (->>
                   (select-keys opts [:recursive :preserve])
                   (filter val)
-                  (map (fn [k v] (k flags))))))
+                  (map (comp flags key)))))
                (string/join " " remote-paths))
+          _ (println cmd)
           _ (logging/tracef "scp-from: %s" cmd)
           {:keys [^ChannelExec channel
                   ^PipedInputStream out-stream]}


### PR DESCRIPTION
Support for :recursive and :preserve called (map) on a kv map without destructuring the pairs, resulting in an arity mismatch exception. This patch pulls out the keys so we can pass the -p and -r flags to scp correctly. Recursive is still broken, however--it verifies the output path is a directory, then opens it as a file and clobbers it with each source file in turn.