### PR TITLE
Fix race condition in ssh-exec function when command finishes before …

### DIFF
--- a/src/clj_ssh/ssh.clj
+++ b/src/clj_ssh/ssh.clj
@@ -686,16 +686,15 @@ config options."
       {:channel exec
        :out-stream out-inputstream
        :err-stream err-inputstream}
-      (with-channel-connection exec
-        (while (connected-channel? exec)
-          (Thread/sleep 100))
-        {:exit (.getExitStatus exec)
-         :out (if (= :bytes out)
-                (.toByteArray ^ByteArrayOutputStream out-stream)
-                (.toString out-stream))
-         :err (if (= :bytes out)
-                (.toByteArray ^ByteArrayOutputStream err-stream)
-                (.toString err-stream))}))))
+      (do (while (connected-channel? exec)
+            (Thread/sleep 100))
+          {:exit (.getExitStatus exec)
+           :out (if (= :bytes out)
+                  (.toByteArray ^ByteArrayOutputStream out-stream)
+                  (.toString out-stream))
+           :err (if (= :bytes out)
+                  (.toByteArray ^ByteArrayOutputStream err-stream)
+                  (.toString err-stream))}))))
 
 (defn ssh
   "Execute commands over ssh.


### PR DESCRIPTION
…we enter with-channel-connection.

In the ssh-exec function, if the command executed through ssh-exec-proc finishes before we get to with-channel-connection, with-channel-connection reopens the channel and the thread is stuck in a loop sleeping with an open ssh connection to the node. I do not believe with-channel-connection is necessary here.

All tests pass on my machine.