### PR TITLE
Fix throw arity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ autodoc/**
 doc/**
 .lein-*
 .nrepl-*
+.idea
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def agentproxy-version "0.0.7")
 
-(defproject raspasov/clj-ssh "0.5.12-SNAPSHOT"
+(defproject com.raspasov/clj-ssh "0.5.12-SNAPSHOT"
   :description "Library for using SSH from clojure."
   :url "https://github.com/raspasov/clj-ssh"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (def agentproxy-version "0.0.7")
 
-(defproject clj-ssh "0.5.12-SNAPSHOT"
+(defproject raspasov/clj-ssh "0.5.12-SNAPSHOT"
   :description "Library for using SSH from clojure."
-  :url "https://github.com/hugoduncan/clj-ssh"
+  :url "https://github.com/raspasov/clj-ssh"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def agentproxy-version "0.0.7")
 
-(defproject com.raspasov/clj-ssh "0.5.12-SNAPSHOT"
+(defproject com.raspasov/clj-ssh "0.5.12"
   :description "Library for using SSH from clojure."
   :url "https://github.com/raspasov/clj-ssh"
   :license {:name "Eclipse Public License"

--- a/src/clj_ssh/ssh.clj
+++ b/src/clj_ssh/ssh.clj
@@ -295,10 +295,10 @@ keyword argument, or constructed from the other keyword arguments.
           (do
             (logging/error "Passphrase required, but none findable.")
             (throw
-             (ex-info
-              (str "Passphrase required for key " name ", but none findable.")
-              {:reason :passphrase-not-found
-               :key-name name}) name)))
+              (ex-info
+                (str "Passphrase required for key " name ", but none findable.")
+                {:reason   :passphrase-not-found
+                 :key-name name} name))))
         (add-identity agent options)))))
 
 ;;; Sessions


### PR DESCRIPTION
Doesn't compile in Clojure 1.8 because of (throw) arity typo.