### PR TITLE
Clojure 1.8.0 compatibility

### DIFF
--- a/profiles.clj
+++ b/profiles.clj
@@ -2,10 +2,12 @@
  {:dependencies [[ch.qos.logback/logback-classic "1.0.0"]]
   :plugins [[lein-pallet-release "RELEASE"]]
   :aliases {"test" ["with-profile"
-                    "clojure-1.4.0:clojure-1.5.1:clojure-1.6.0"
+                    "clojure-1.4.0:clojure-1.5.1:clojure-1.6.0:clojure-1.7.0:clojure-1.8.0"
                     "test"]}}
  :clojure-1.2.1 {:dependencies [[org.clojure/clojure "1.2.1"]]}
  :clojure-1.3.0 {:dependencies [[org.clojure/clojure "1.3.0"]]}
  :clojure-1.4.0 {:dependencies [[org.clojure/clojure "1.4.0"]]}
  :clojure-1.5.1 {:dependencies [[org.clojure/clojure "1.5.1"]]}
- :clojure-1.6.0 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
+ :clojure-1.6.0 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+ :clojure-1.7.0 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+ :clojure-1.8.0 {:dependencies [[org.clojure/clojure "1.8.0"]]}}

--- a/project.clj
+++ b/project.clj
@@ -16,3 +16,4 @@
                  [com.jcraft/jsch.agentproxy.jsch ~agentproxy-version]
                  [com.jcraft/jsch "0.1.51"]]
   :jvm-opts ["-Djava.awt.headless=true"])
+

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.logging "0.3.1"
+                 [org.clojure/tools.logging "0.2.6"
                   :exclusions [org.clojure/clojure]]
                  [com.jcraft/jsch.agentproxy.usocket-jna ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.usocket-nc ~agentproxy-version]
@@ -14,5 +14,5 @@
                  [com.jcraft/jsch.agentproxy.pageant ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.core ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.jsch ~agentproxy-version]
-                 [com.jcraft/jsch "0.1.53"]]
+                 [com.jcraft/jsch "0.1.51"]]
   :jvm-opts ["-Djava.awt.headless=true"])

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
   :url "https://github.com/hugoduncan/clj-ssh"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/tools.logging "0.2.6"
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/tools.logging "0.3.1"
                   :exclusions [org.clojure/clojure]]
                  [com.jcraft/jsch.agentproxy.usocket-jna ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.usocket-nc ~agentproxy-version]
@@ -14,5 +14,5 @@
                  [com.jcraft/jsch.agentproxy.pageant ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.core ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.jsch ~agentproxy-version]
-                 [com.jcraft/jsch "0.1.51"]]
+                 [com.jcraft/jsch "0.1.53"]]
   :jvm-opts ["-Djava.awt.headless=true"])

--- a/src/clj_ssh/ssh.clj
+++ b/src/clj_ssh/ssh.clj
@@ -298,7 +298,7 @@ keyword argument, or constructed from the other keyword arguments.
              (ex-info
               (str "Passphrase required for key " name ", but none findable.")
               {:reason :passphrase-not-found
-               :key-name name}) name)))
+               :key-name name}))))
         (add-identity agent options)))))
 
 ;;; Sessions


### PR DESCRIPTION
Hi,

Here is a small PR to make clj-ssh compatible with clojure 1.8.0. This resolves issue #39 , any project using both clojure 1.8.0 and clj-ssh could not be compiled.

Note that I wasn't able to run the tests, they were all complaining about a missing ~/.ssh/clj_ssh key.

Also, it may not be required to change the clojure version within project.clj, not sure what your policy is.

Thanks,
Reynald
