### PR TITLE
Clojure 1.8: Remove extra arg to throw

### DIFF
--- a/profiles.clj
+++ b/profiles.clj
@@ -2,10 +2,12 @@
  {:dependencies [[ch.qos.logback/logback-classic "1.0.0"]]
   :plugins [[lein-pallet-release "RELEASE"]]
   :aliases {"test" ["with-profile"
-                    "clojure-1.4.0:clojure-1.5.1:clojure-1.6.0"
+                    "clojure-1.4.0:clojure-1.5.1:clojure-1.6.0:clojure-1.7.0:clojure-1.8.0"
                     "test"]}}
  :clojure-1.2.1 {:dependencies [[org.clojure/clojure "1.2.1"]]}
  :clojure-1.3.0 {:dependencies [[org.clojure/clojure "1.3.0"]]}
  :clojure-1.4.0 {:dependencies [[org.clojure/clojure "1.4.0"]]}
  :clojure-1.5.1 {:dependencies [[org.clojure/clojure "1.5.1"]]}
- :clojure-1.6.0 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
+ :clojure-1.6.0 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+ :clojure-1.7.0 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+ :clojure-1.8.0 {:dependencies [[org.clojure/clojure "1.8.0"]]}}

--- a/src/clj_ssh/ssh.clj
+++ b/src/clj_ssh/ssh.clj
@@ -298,7 +298,7 @@ keyword argument, or constructed from the other keyword arguments.
              (ex-info
               (str "Passphrase required for key " name ", but none findable.")
               {:reason :passphrase-not-found
-               :key-name name}) name)))
+               :key-name name}))))
         (add-identity agent options)))))
 
 ;;; Sessions


### PR DESCRIPTION
This makes clj-ssh compatible with Clojure 1.8, which does not allow the extra argument to throw.

This should resolve #39.