### PR TITLE
Check existence of known_hosts file

### DIFF
--- a/src/clj_ssh/ssh.clj
+++ b/src/clj_ssh/ssh.clj
@@ -146,7 +146,8 @@
   (let [agent (JSch.)]
     (when use-system-ssh-agent
       (agent/connect agent))
-    (when known-hosts-path
+    (when (and known-hosts-path
+               (.exists (io/file known-hosts-path)))
       (locking hosts-file
         (.setKnownHosts agent known-hosts-path)))
     agent))


### PR DESCRIPTION
If the machine doing the compilation does not have a file at `$HOME/.ssh/known_hosts`, the compilation (repl or jar or uberjar) fails.

Right now I'm getting around the issue with below hack.
```
(defn touch [path]
  (with-open [writer (io/writer (io/file path)
                                :append true)]
    (spit writer "")))

(when-not (contains? (loaded-libs) 'clj-ssh.agent)
  (touch (str (System/getProperty "user.home") "/.ssh/known_hosts"))
  (load "/clj_ssh/cli")
  (alias 'whatever 'clj-ssh.cli))
```

No tests added, but I'm not sure how to add one without making it complicated with `alter-root-var` and `proxy` tricks.