### PR TITLE
clj-ssh should work when known_hosts file is absent.

### DIFF
--- a/src/clj_ssh/ssh.clj
+++ b/src/clj_ssh/ssh.clj
@@ -146,7 +146,7 @@
   (let [agent (JSch.)]
     (when use-system-ssh-agent
       (agent/connect agent))
-    (when known-hosts-path
+    (when-not (= :no-default-path known-hosts-path)
       (locking hosts-file
         (.setKnownHosts agent known-hosts-path)))
     agent))


### PR DESCRIPTION
- Allow for not using the default known_hosts file
when creating the ssh-agent. This is useful in cases
where strict-host-key-checking is set to no and we
don't have a known_hosts file in the usual location